### PR TITLE
ProfileList 부분 컴포넌트로 분리 완료, CardList api연동 완료

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 import GlobalStyle from './assets/styles/Global.styled';
 import Header from './components/Header/Header';
-import CardFolder from './components/CardFolder/CardFolder';
 
 function App() {
   return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,6 @@ function App() {
     <>
       <GlobalStyle />
       <Header />
-      <CardFolder />
       <Outlet />
     </>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 import GlobalStyle from './assets/styles/Global.styled';
 import Header from './components/Header/Header';
+import CardFolder from './components/CardFolder/CardFolder';
 
 function App() {
   return (
     <>
       <GlobalStyle />
       <Header />
+      <CardFolder />
       <Outlet />
     </>
   );

--- a/src/components/CardFolder/CardFolder.jsx
+++ b/src/components/CardFolder/CardFolder.jsx
@@ -1,38 +1,28 @@
-import { useEffect, useState } from 'react';
-import { getMockImageRequest } from '../../apis/api';
-import ProfileImage from '../ProfileImage/ProfileImage';
-import useAsync from '../../hooks/useAsync';
 import * as S from './CardFolder.styled';
 import EmojiBadge from '../EmojiBadge/EmojiBadge';
 import ProfileList from '../ProfileList/ProfileList';
 
-function CardFolder({
-  name = 'Sowon',
-  backgroundImageURL = 'url(https://picsum.photos/id/24/3840/2160)',
-  backgroundColor = 'beige',
-  messageCount = 21,
-  topReactions,
-  recentMessages,
-}) {
-  // const [profileImage, setProfileImage] = useState([]);
-  // const { requestFunction: getProfileImage } = useAsync(getMockImageRequest);
+function CardFolder({ userInfo }) {
+  const {
+    name = 'Sowon',
+    backgroundImageURL = 'url(https://picsum.photos/id/24/3840/2160)',
+    backgroundColor = 'beige',
+    messageCount = 21,
+    topReactions = null,
+    recentMessages = null,
+  } = userInfo;
 
-  // const getImage = async () => {
-  //   const result = await getProfileImage();
-  //   if (!result) return;
-
-  //   const {
-  //     data: { imageUrls },
-  //   } = result;
-  //   setProfileImage(imageUrls.slice(-3));
-  // };
-
-  // useEffect(() => {
-  //   getImage();
-  // }, []);
+  const colorConversion = (color) => {
+    if (color === 'beige') {
+      return 'var(--orange-200)';
+    }
+    return `var(--${color}-200)`;
+  };
 
   return (
-    <S.CardFolderLayout $background={backgroundImageURL || backgroundColor}>
+    <S.CardFolderLayout
+      $background={backgroundImageURL || colorConversion(backgroundColor)}
+    >
       <S.UserInfoContainer>
         <S.CardUserNameBox>To. {name}</S.CardUserNameBox>
         <S.CardGuestContainer>
@@ -41,7 +31,11 @@ function CardFolder({
             messageCount={messageCount}
           />
         </S.CardGuestContainer>
-        <S.VisitCountBox>{`${messageCount}명이 작성했어요!`}</S.VisitCountBox>
+        {messageCount ? (
+          <S.VisitCountBox>{`${messageCount}명이 작성했어요!`}</S.VisitCountBox>
+        ) : (
+          '페이퍼 남기러 가요~'
+        )}
       </S.UserInfoContainer>
       <S.CardEmojiContainer>
         {topReactions?.map((item) => (

--- a/src/components/CardFolder/CardFolder.jsx
+++ b/src/components/CardFolder/CardFolder.jsx
@@ -12,7 +12,7 @@ function CardFolder({ userInfo }) {
     recentMessages = null,
   } = userInfo;
 
-  const colorConversion = (color) => {
+  const convertColor = (color) => {
     if (color === 'beige') {
       return 'var(--orange-200)';
     }
@@ -21,7 +21,7 @@ function CardFolder({ userInfo }) {
 
   return (
     <S.CardFolderLayout
-      $background={backgroundImageURL || colorConversion(backgroundColor)}
+      $background={backgroundImageURL || convertColor(backgroundColor)}
     >
       <S.UserInfoContainer>
         <S.CardUserNameBox>To. {name}</S.CardUserNameBox>

--- a/src/components/CardFolder/CardFolder.jsx
+++ b/src/components/CardFolder/CardFolder.jsx
@@ -6,10 +6,11 @@ import * as S from './CardFolder.styled';
 import EmojiBadge from '../EmojiBadge/EmojiBadge';
 
 function CardFolder({
-  currentUserReceivedEmojiInfo,
-  currentUserVisitorInfo,
-  userName = 'Sowon',
-  background = 'var(--orange-200)',
+  name = 'Sowon',
+  backgroundImageURL = 'url(https://picsum.photos/id/24/3840/2160)',
+  backgroundColor = 'beige',
+  messageCount = 21,
+  topReactions,
 }) {
   const [profileImage, setProfileImage] = useState([]);
   const { requestFunction: getProfileImage } = useAsync(getMockImageRequest);
@@ -29,23 +30,23 @@ function CardFolder({
   }, []);
 
   return (
-    <S.CardFolderLayout $background={background}>
+    <S.CardFolderLayout $background={backgroundImageURL || backgroundColor}>
       <S.UserInfoContainer>
-        <S.CardUserNameBox>To. {userName}</S.CardUserNameBox>
+        <S.CardUserNameBox>To. {name}</S.CardUserNameBox>
         <S.CardGuestContainer>
           {profileImage.map((image, index) => (
             <ProfileImage key={index} image={image} />
           ))}
           {profileImage.length >= 1 ? (
-            <S.WroteCountBox>+27</S.WroteCountBox>
+            <S.WroteCountBox>{`+${messageCount}`}</S.WroteCountBox>
           ) : null}
         </S.CardGuestContainer>
-        <S.VisitCountBox>30명이 작성했어요!</S.VisitCountBox>
+        <S.VisitCountBox>{`${messageCount}명이 작성했어요!`}</S.VisitCountBox>
       </S.UserInfoContainer>
       <S.CardEmojiContainer>
-        <EmojiBadge />
-        <EmojiBadge emoji={'1f44d'} count={'15'} />
-        <EmojiBadge emoji={'1f604'} count={'20'} />
+        {topReactions?.map((item) => (
+          <EmojiBadge key={item.id} emoji={item.emoji} count={item.count} />
+        ))}
       </S.CardEmojiContainer>
     </S.CardFolderLayout>
   );

--- a/src/components/CardFolder/CardFolder.jsx
+++ b/src/components/CardFolder/CardFolder.jsx
@@ -4,6 +4,7 @@ import ProfileImage from '../ProfileImage/ProfileImage';
 import useAsync from '../../hooks/useAsync';
 import * as S from './CardFolder.styled';
 import EmojiBadge from '../EmojiBadge/EmojiBadge';
+import ProfileList from '../ProfileList/ProfileList';
 
 function CardFolder({
   name = 'Sowon',
@@ -11,35 +12,34 @@ function CardFolder({
   backgroundColor = 'beige',
   messageCount = 21,
   topReactions,
+  recentMessages,
 }) {
-  const [profileImage, setProfileImage] = useState([]);
-  const { requestFunction: getProfileImage } = useAsync(getMockImageRequest);
+  // const [profileImage, setProfileImage] = useState([]);
+  // const { requestFunction: getProfileImage } = useAsync(getMockImageRequest);
 
-  const getImage = async () => {
-    const result = await getProfileImage();
-    if (!result) return;
+  // const getImage = async () => {
+  //   const result = await getProfileImage();
+  //   if (!result) return;
 
-    const {
-      data: { imageUrls },
-    } = result;
-    setProfileImage(imageUrls.slice(-3));
-  };
+  //   const {
+  //     data: { imageUrls },
+  //   } = result;
+  //   setProfileImage(imageUrls.slice(-3));
+  // };
 
-  useEffect(() => {
-    getImage();
-  }, []);
+  // useEffect(() => {
+  //   getImage();
+  // }, []);
 
   return (
     <S.CardFolderLayout $background={backgroundImageURL || backgroundColor}>
       <S.UserInfoContainer>
         <S.CardUserNameBox>To. {name}</S.CardUserNameBox>
         <S.CardGuestContainer>
-          {profileImage.map((image, index) => (
-            <ProfileImage key={index} image={image} />
-          ))}
-          {profileImage.length >= 1 ? (
-            <S.WroteCountBox>{`+${messageCount}`}</S.WroteCountBox>
-          ) : null}
+          <ProfileList
+            recentMessages={recentMessages}
+            messageCount={messageCount}
+          />
         </S.CardGuestContainer>
         <S.VisitCountBox>{`${messageCount}명이 작성했어요!`}</S.VisitCountBox>
       </S.UserInfoContainer>

--- a/src/components/CardFolder/CardFolder.styled.js
+++ b/src/components/CardFolder/CardFolder.styled.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 export const CardFolderLayout = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -9,9 +10,33 @@ export const CardFolderLayout = styled.div`
   padding: 30px 24px 20px 24px;
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 10%;
-  object-fit: cover;
   box-shadow: 0px 2px 12px 0px rgba(0, 0, 0, 0.08);
-  background: ${({ $background }) => $background};
+  overflow: hidden;
+
+  > div {
+    z-index: 100;
+  }
+
+  ${({ $background }) => {
+    if ($background.includes('url')) {
+      return `
+      background-image: ${$background};
+      background-size: cover;
+      color: var(--white-color);
+
+        &::after {
+          position: absolute;
+          content: '';
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background-color: rgba(0, 0, 0, 0.2);
+        }
+      `;
+    }
+    return `${$background}`;
+  }}
 `;
 
 export const UserInfoContainer = styled.div``;
@@ -38,6 +63,7 @@ export const WroteCountBox = styled.div`
   padding: 5px 6px 4px 6px;
   border-radius: 30px;
   background-color: var(--white-color);
+  color: var(--black-color);
   font-size: 12px;
   font-weight: 400;
 `;

--- a/src/components/CardFolder/CardFolder.styled.js
+++ b/src/components/CardFolder/CardFolder.styled.js
@@ -35,7 +35,7 @@ export const CardFolderLayout = styled.div`
         }
       `;
     }
-    return `${$background}`;
+    return `background-color:${$background}`;
   }}
 `;
 
@@ -54,18 +54,6 @@ export const CardGuestContainer = styled.div`
     border: 1.5px solid var(--white-color);
     margin-right: -10px;
   }
-`;
-
-export const WroteCountBox = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 5px 6px 4px 6px;
-  border-radius: 30px;
-  background-color: var(--white-color);
-  color: var(--black-color);
-  font-size: 12px;
-  font-weight: 400;
 `;
 
 export const VisitCountBox = styled.div`

--- a/src/components/EmojiBadge/EmojiBadge.jsx
+++ b/src/components/EmojiBadge/EmojiBadge.jsx
@@ -1,10 +1,9 @@
-import { Emoji } from 'emoji-picker-react';
 import * as S from './EmojiBadge.styled';
 
-function EmojiBadge({ emoji = '1f423', count = '20' }) {
+function EmojiBadge({ emoji, count = '0' }) {
   return (
     <S.EmojiBadgeLayout>
-      <Emoji unified={emoji} size="16" />
+      {emoji}
       {count}
     </S.EmojiBadgeLayout>
   );

--- a/src/components/EmojiBadge/EmojiBadge.styled.js
+++ b/src/components/EmojiBadge/EmojiBadge.styled.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const EmojiBadgeLayout = styled.span`
   display: inline-flex;
-  gap: 4px;
+  gap: 6px;
   padding: 8px 12px;
   border-radius: 32px;
   color: var(--white-color);

--- a/src/components/ProfileList/ProfileList.jsx
+++ b/src/components/ProfileList/ProfileList.jsx
@@ -1,5 +1,15 @@
 import * as S from './ProfileList.styled';
+import ProfileImage from '../ProfileImage/ProfileImage';
 
-export default function ProfileList() {
-  return;
+export default function ProfileList({ recentMessages, messageCount }) {
+  return (
+    <>
+      {recentMessages.map((item) => (
+        <ProfileImage key={item.id} image={item.profileImageURL} />
+      ))}
+      {messageCount.length > recentMessages.length ? (
+        <S.WroteCountBox>{`+${messageCount}`}</S.WroteCountBox>
+      ) : null}
+    </>
+  );
 }

--- a/src/components/ProfileList/ProfileList.jsx
+++ b/src/components/ProfileList/ProfileList.jsx
@@ -4,10 +4,10 @@ import ProfileImage from '../ProfileImage/ProfileImage';
 export default function ProfileList({ recentMessages, messageCount }) {
   return (
     <>
-      {recentMessages.map((item) => (
+      {recentMessages?.map((item) => (
         <ProfileImage key={item.id} image={item.profileImageURL} />
       ))}
-      {messageCount > recentMessages.length ? (
+      {messageCount > recentMessages?.length ? (
         <S.WroteCountBox>{`+ ${messageCount}`}</S.WroteCountBox>
       ) : null}
     </>

--- a/src/components/ProfileList/ProfileList.jsx
+++ b/src/components/ProfileList/ProfileList.jsx
@@ -7,8 +7,8 @@ export default function ProfileList({ recentMessages, messageCount }) {
       {recentMessages.map((item) => (
         <ProfileImage key={item.id} image={item.profileImageURL} />
       ))}
-      {messageCount.length > recentMessages.length ? (
-        <S.WroteCountBox>{`+${messageCount}`}</S.WroteCountBox>
+      {messageCount > recentMessages.length ? (
+        <S.WroteCountBox>{`+ ${messageCount}`}</S.WroteCountBox>
       ) : null}
     </>
   );

--- a/src/components/ProfileList/ProfileList.jsx
+++ b/src/components/ProfileList/ProfileList.jsx
@@ -1,0 +1,5 @@
+import * as S from './ProfileList.styled';
+
+export default function ProfileList() {
+  return;
+}

--- a/src/components/ProfileList/ProfileList.styled.js
+++ b/src/components/ProfileList/ProfileList.styled.js
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const WroteCountBox = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 5px 6px 4px 6px;
+  border-radius: 30px;
+  background-color: var(--white-color);
+  color: var(--black-color);
+  font-size: 12px;
+  font-weight: 400;
+`;

--- a/src/pages/ApiTestPage/ApiTestPage.jsx
+++ b/src/pages/ApiTestPage/ApiTestPage.jsx
@@ -91,10 +91,13 @@ const GetPaper = () => {
     setPaperList(results);
   };
 
+  if (paperList) console.log(paperList);
+
   const handleSubmit = (e) => {
     e.preventDefault();
     getRequest();
   };
+
   return (
     <S.TestLayout>
       <form>


### PR DESCRIPTION
- [x] CardList api 연동 완료
- [x] CardList 프로필 이미지 부분 개별 컴포넌트화 (ProfileList)

컴포넌트 분리작업 특성상 겹치는 부분이 많아 브랜치 구분해서 작업하단 실수할것 같아서 한 브랜치에서 작업하였습니다.


그리고 api에서 받는 backgroundColor에 beige를 받는 부분이 있는데요. 피그마 예제에 orange랑 같은 색이더라구요. 

이름이 달라 CardList 컴포넌트 안에 따로 함수로 문자열 바꿔주는 부분이 있는데 글로벌 css에서 orange 부분을 beige로 수정하는건 어떨까 건의해봐요~ 


![스크린샷 2024-04-12 시간: 19 11 02](https://github.com/Codeit-Sprint-Part2-5team/Rolling/assets/70879978/ab0e2e39-ed22-4a61-989e-fedc14034005)
<img width="149" alt="스크린샷 2024-04-12 13 49 27" src="https://github.com/Codeit-Sprint-Part2-5team/Rolling/assets/70879978/5f217e86-91f3-482e-9cac-830cc59d7c3e">
