### PR TITLE
Rolling페이지 무한스크롤 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@uiw/react-md-editor": "^4.0.4",
         "axios": "^1.6.8",
         "emoji-picker-react": "^4.9.2",
+        "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@uiw/react-md-editor": "^4.0.4",
     "axios": "^1.6.8",
     "emoji-picker-react": "^4.9.2",
+    "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",

--- a/src/hooks/useInfiniteScroll.js
+++ b/src/hooks/useInfiniteScroll.js
@@ -1,0 +1,31 @@
+import { throttle } from 'lodash';
+import { useEffect } from 'react';
+
+const THROTTLE_WAIT = 300;
+
+export default function useInfiniteScroll(callback) {
+  const [isFetching, setIsFetching] = useState(false);
+
+  const handleScrollThrottle = throttle(() => {
+    const isScrollOver =
+      window.innerHeight + document.documentElement.scrollTop >=
+      document.documentElement.offsetHeight;
+    if (isScrollOver) {
+      setIsFetching(true);
+    }
+  }, THROTTLE_WAIT);
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScrollThrottle);
+    return () => {
+      window.removeEventListener('scroll', handleScrollThrottle);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isFetching) return;
+    callback();
+  }, [isFetching]);
+
+  return [isFetching, setIsFetching];
+}

--- a/src/hooks/useInfiniteScroll.js
+++ b/src/hooks/useInfiniteScroll.js
@@ -1,14 +1,14 @@
 import { throttle } from 'lodash';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 const THROTTLE_WAIT = 300;
 
-export default function useInfiniteScroll(callback) {
+export default function useInfiniteScroll(fetchCallback) {
   const [isFetching, setIsFetching] = useState(false);
 
   const handleScrollThrottle = throttle(() => {
     const isScrollOver =
-      window.innerHeight + document.documentElement.scrollTop >=
+      window.innerHeight + document.documentElement.scrollTop + 20 >=
       document.documentElement.offsetHeight;
     if (isScrollOver) {
       setIsFetching(true);
@@ -24,7 +24,7 @@ export default function useInfiniteScroll(callback) {
 
   useEffect(() => {
     if (!isFetching) return;
-    callback();
+    fetchCallback();
   }, [isFetching]);
 
   return [isFetching, setIsFetching];

--- a/src/pages/RollingPage/RollingPage.jsx
+++ b/src/pages/RollingPage/RollingPage.jsx
@@ -27,8 +27,8 @@ export default function RollingPage({ edit }) {
   const { userId } = useParams();
   const navigate = useNavigate();
 
-  const getMessageData = async () => {
-    const result = await getMessageList(userId);
+  const getMessageData = async (limit) => {
+    const result = await getMessageList(userId, limit);
     if (!result) return;
     const {
       data: { results },

--- a/src/pages/RollingPage/RollingPage.jsx
+++ b/src/pages/RollingPage/RollingPage.jsx
@@ -29,8 +29,11 @@ export default function RollingPage({ edit }) {
   const navigate = useNavigate();
   const [dataLimit, setDataLimit] = useState(8);
   const [isFetching, setIsFetching] = useInfiniteScroll(updateFunctionOnScroll);
+  const [messageCount, setMessageCount] = useState();
 
   function updateFunctionOnScroll() {
+    const noMoreData = messageCount && dataLimit - 9 > messageCount;
+    if (noMoreData) return;
     setDataLimit((prev) => prev + 9);
     getMessageData(dataLimit);
     setIsFetching(false);
@@ -38,7 +41,7 @@ export default function RollingPage({ edit }) {
 
   useEffect(() => {
     updateFunctionOnScroll();
-  }, [isFetching]);
+  }, []);
 
   const getMessageData = async (limit) => {
     const result = await getMessageList(userId, limit);
@@ -54,6 +57,7 @@ export default function RollingPage({ edit }) {
     if (!result) return;
     const { data } = result;
     setRecipient(data);
+    setMessageCount(data.messageCount);
   };
 
   const deleteAll = async () => {

--- a/src/pages/RollingPage/RollingPage.jsx
+++ b/src/pages/RollingPage/RollingPage.jsx
@@ -13,6 +13,7 @@ import HeaderService from '../../components/HeaderService/HeaderService';
 import Modal from '../../components/Modal/Modal';
 import { useNavigate, useParams } from 'react-router-dom';
 import convertBackgroundColor from '../../utils/convertBackgroundColor';
+import useInfiniteScroll from '../../hooks/useInfiniteScroll';
 
 export default function RollingPage({ edit }) {
   const [messageList, setMessageList] = useState();
@@ -26,6 +27,18 @@ export default function RollingPage({ edit }) {
   const { requestFunction: deleteMessageCard } = useAsync(deleteMessageRequest);
   const { userId } = useParams();
   const navigate = useNavigate();
+  const [dataLimit, setDataLimit] = useState(8);
+  const [isFetching, setIsFetching] = useInfiniteScroll(updateFunctionOnScroll);
+
+  function updateFunctionOnScroll() {
+    setDataLimit((prev) => prev + 9);
+    getMessageData(dataLimit);
+    setIsFetching(false);
+  }
+
+  useEffect(() => {
+    updateFunctionOnScroll();
+  }, [isFetching]);
 
   const getMessageData = async (limit) => {
     const result = await getMessageList(userId, limit);


### PR DESCRIPTION
- [x] Rolling페이지 스크롤 시 메세지가 9개씩 추가로 보이도록 구현

- 맨 처음엔 +버튼 카드가 있어서 8개를 호출하고, 그 이후엔 9개씩 추가로 호출하도록 구현하였습니다.
- 데이터가 모두 나온 이후에는 스크롤을 하더라도 api를 더 이상 호출하지 않도록 구현하였습니다.

https://github.com/Codeit-Sprint-Part2-5team/Rolling/assets/105799083/79009a26-dd16-48f2-b6ff-452c420d00cd
