### PR TITLE
listpage 반응형 완료

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,8 +1,10 @@
 import * as S from './Button.styled';
+import { Link } from 'react-router-dom';
 import smileIcon from '../../assets/images/smileIcon.svg';
 import smileWhiteIcon from '../../assets/images/SmileWhiteIcon.svg';
 
 export default function Button({
+  to, // 링크 주소를 받음
   text, // 버튼 내부에 들어갈 텍스트 입력
   variant, // 버튼 색상 지정 - primary, secondery, outline
   size, // height값을 기준으로 버튼 별 크기 지정 - 56, 40, 36, 28
@@ -12,7 +14,33 @@ export default function Button({
   onClick,
   className,
 }) {
-  return (
+  const buttonContent = (
+    <>
+      {isSmileIcon === 'on' ? (
+        <S.SmileIconImg
+          src={disabled ? smileWhiteIcon : smileIcon}
+          alt='스마일'
+        />
+      ) : null}
+      {text}
+    </>
+  );
+
+  return to ? (
+    <Link to={to} style={{ textDecoration: 'none' }}>
+      <S.ButtonLayout
+        className={className}
+        $variant={variant}
+        size={size}
+        width={width}
+        disabled={disabled}
+        $smileicon={isSmileIcon}
+        onClick={onClick}
+      >
+        {buttonContent}
+      </S.ButtonLayout>
+    </Link>
+  ) : (
     <S.ButtonLayout
       className={className}
       $variant={variant}
@@ -22,13 +50,7 @@ export default function Button({
       $smileicon={isSmileIcon}
       onClick={onClick}
     >
-      {isSmileIcon === 'on' ? (
-        <S.SmileIconImg
-          src={disabled ? smileWhiteIcon : smileIcon}
-          alt='스마일'
-        />
-      ) : null}
-      {text}
+      {buttonContent}
     </S.ButtonLayout>
   );
 }

--- a/src/components/CardSlider/CardSlider.jsx
+++ b/src/components/CardSlider/CardSlider.jsx
@@ -9,7 +9,6 @@ function CardSlider({ children }) {
   const [showLeftButton, setShowLeftButton] = useState(false);
   const [showRightButton, setShowRightButton] = useState(true);
 
-  // 카드 너비 계산
   const calculateCardCount = () => {
     const cardListWidth = sliderRef.current.offsetWidth;
     return Math.floor((cardListWidth + gap) / (cardFolderWidth + gap));
@@ -42,7 +41,15 @@ function CardSlider({ children }) {
       // eslint-disable-next-line
       sliderRef.current.removeEventListener('scroll', handleScroll);
     };
-  }, [sliderRef]);
+  }, []);
+
+  useEffect(() => {
+    if (sliderRef.current && children.length * (cardFolderWidth + gap) > sliderRef.current.offsetWidth) {
+      setShowRightButton(true);
+    } else {
+      setShowRightButton(false);
+    }
+  }, [children, cardFolderWidth, gap]);
 
   return (
     <S.CardSlider>

--- a/src/components/CardSlider/CardSlider.styled.js
+++ b/src/components/CardSlider/CardSlider.styled.js
@@ -28,16 +28,19 @@ export const RightButton = styled(ArrowButton)`
 
 export const CardSlider = styled.div`
   position: relative;
+  display: flex;
+  justify-content: center;
 `;
 
 export const CardList = styled.div`
   display: flex;
   flex-wrap: nowrap;
   align-items: flex-start;
-  width: 1160px;
+  width: 100%;
+  max-width: 1160px;
   padding: 0px;
   gap: 20px;
-  margin-left: 20px;
+  margin: 0 auto;
   overflow-x: auto;
   scroll-behavior: smooth;
 

--- a/src/components/CardSlider/CardSlider.styled.js
+++ b/src/components/CardSlider/CardSlider.styled.js
@@ -8,6 +8,10 @@ export const LeftButton = styled(ArrowButton)`
   transform: translateY(-50%) rotate(180deg);
   // arrowLeftIcon이 연결되지 않아 회전시킴
   z-index: 1;
+
+  @media (max-width: 1248px) {
+    display: none;
+  }
 `;
 
 export const RightButton = styled(ArrowButton)`
@@ -16,6 +20,10 @@ export const RightButton = styled(ArrowButton)`
   right: 0;
   transform: translateY(-50%);
   z-index: 1;
+
+  @media (max-width: 1248px) {
+    display: none;
+  }
 `;
 
 export const CardSlider = styled.div`

--- a/src/pages/ListPage/ListPage.jsx
+++ b/src/pages/ListPage/ListPage.jsx
@@ -18,11 +18,13 @@ export default function ListPage() {
     const getData = async () => {
       const result = await getCardDataList(5788);
       if (result && result.data && result.data.results) {
-        setCardDataList(result.data.results);
+        setCardDataList(result.data.results.slice(0, 3));
       }
     };
     getData();
   }, [getCardDataList]);
+
+  
 
   const sortedCardDataByReaction = useMemo(() => {
     return [...cardDataList].sort((a, b) => b.reactionCount - a.reactionCount);

--- a/src/pages/ListPage/ListPage.jsx
+++ b/src/pages/ListPage/ListPage.jsx
@@ -57,8 +57,8 @@ export default function ListPage() {
         </S.CardContainer>
 
         {/* 최근에 만든 롤링 페이퍼 */}
+        <S.TextBox>최근에 만든 롤링 페이퍼⭐️️</S.TextBox>
         <S.RecentCardContainer>
-          <S.TextBox>최근에 만든 롤링 페이퍼⭐️️</S.TextBox>
           <CardSlider>
             {sortedCardDataByCreatedAt.map((card) => (
               <CardFolder

--- a/src/pages/ListPage/ListPage.jsx
+++ b/src/pages/ListPage/ListPage.jsx
@@ -18,7 +18,7 @@ export default function ListPage() {
     const getData = async () => {
       const result = await getCardDataList(5788);
       if (result && result.data && result.data.results) {
-        setCardDataList(result.data.results.slice(0, 3));
+        setCardDataList(result.data.results);
       }
     };
     getData();

--- a/src/pages/ListPage/ListPage.jsx
+++ b/src/pages/ListPage/ListPage.jsx
@@ -6,7 +6,7 @@ import CardFolder from '../../components/CardFolder/CardFolder';
 import useAsync from '../../hooks/useAsync';
 import * as S from './ListPage.styled';
 import { getCardFolderListRequest } from '../../apis/api';
-import CardSlider from '../../components/CardSlider/CardSlider'; // CardSlider 추가
+import CardSlider from '../../components/CardSlider/CardSlider';
 
 export default function ListPage() {
   const [cardDataList, setCardDataList] = useState([]);
@@ -37,26 +37,25 @@ export default function ListPage() {
   return (
     <S.ListPageLayout>
       <Inner>
-        {/* 인기 롤링 페이퍼 */}
         <S.CardContainer>
           <S.TextBox>인기 롤링 페이퍼🔥</S.TextBox>
           <CardSlider>
             {sortedCardDataByReaction.map((card) => (
-              <CardFolder
-                key={card.id}
-                name={card.name}
-                backgroundColor={card.backgroundColor}
-                backgroundImageURL={card.backgroundImageURL}
-                messageCount={card.messageCount}
-                topReactions={card.topReactions}
-                recentMessages={card.recentMessages}
-                sort='like'
-              />
+              <Link to='/userId'>
+                <CardFolder
+                  key={card.id}
+                  name={card.name}
+                  backgroundColor={card.backgroundColor}
+                  backgroundImageURL={card.backgroundImageURL}
+                  messageCount={card.messageCount}
+                  topReactions={card.topReactions}
+                  recentMessages={card.recentMessages}
+                  sort='like'
+                />
+              </Link>
             ))}
           </CardSlider>
         </S.CardContainer>
-
-        {/* 최근에 만든 롤링 페이퍼 */}
         <S.TextBox>최근에 만든 롤링 페이퍼⭐️️</S.TextBox>
         <S.RecentCardContainer>
           <CardSlider>
@@ -73,16 +72,14 @@ export default function ListPage() {
             ))}
           </CardSlider>
         </S.RecentCardContainer>
-
-        {/* 나도 만들어보기 버튼 */}
         <S.ButtonContainer>
-        <Link to="/post">
-          <Button
-            variant={'primary'}
-            text={'나도 만들어보기'}
-            size={56}
-            width={'280px'}
-          />
+          <Link to='/post'>
+            <Button
+              variant={'primary'}
+              text={'나도 만들어보기'}
+              size={56}
+              width={'280px'}
+            />
           </Link>
         </S.ButtonContainer>
       </Inner>

--- a/src/pages/ListPage/ListPage.styled.js
+++ b/src/pages/ListPage/ListPage.styled.js
@@ -14,6 +14,10 @@ export const TextBox = styled.h4`
   margin-left: 20px;
   margin-top: 50px;
   margin-bottom: 16px;
+
+  @media (max-width: 1248px) {
+    margin-left:0px;
+  }
 `;
 
 export const ListPageLayout = styled.div``;

--- a/src/pages/ListPage/ListPage.styled.js
+++ b/src/pages/ListPage/ListPage.styled.js
@@ -1,12 +1,9 @@
 import styled from 'styled-components';
 
 export const CardContainer = styled.div`
-  // 인기순 카드 목록 컨테이너(h 태그 + CardList)
   position: relative;
   flex-direction: column;
   width: 100%;
-  gap: 5px;
-  // margin-top: 20px; ui 조정중
 `;
 
 export const TextBox = styled.h4`
@@ -15,21 +12,19 @@ export const TextBox = styled.h4`
   line-height: 36px;
   letter-spacing: -0.01em;
   margin-left: 20px;
-  margin-bottom: 218px;
+  margin-top: 50px;
+  margin-bottom: 16px;
 `;
 
-export const ListPageLayout = styled.div`
-  padding: 20px 0 100px;
-  overflow-y: hidden;
-`;
+export const ListPageLayout = styled.div``;
 
 export const RecentCardContainer = styled.div`
-  // 최신순 카드 목록 컨테이너
-  margin-top: 50px;
+  // textbox 제외 컨테이너
+  margin-top: 32px;
 `;
 
 export const ButtonContainer = styled.div`
   display: flex;
   justify-content: center;
-  margin-top: 50px;
+  margin-top: 48px;
 `;


### PR DESCRIPTION
- [x] '로고' 버튼을 클릭하면 / 페이지로 이동합니다.
- [x] '롤링 페이퍼 만들기' 버튼을 클릭하면 /post 페이지로 이동합니다.
- [x] '나도 만들어보기' 버튼을 클릭하면 /post 페이지로 이동합니다.
- [x] 생성된 카드를 클릭하면 /post{id} 페이지로 이동합니다
- [x] PC에서 롤링 페이퍼 카드 목록 영역의 너비는 고정합니다.
- [x] PC에서 좌/우측 버튼 클릭 시 다음 순서의 롤링 페이퍼 카드들이 보입니다.
- [x] PC에서 첫 순서일 때는 좌측 버튼이 보이지 않고, 마지막 순서일 때는 우측 버튼이 보이지 않습니다.
- [x] 롤링 페이퍼 카드의 개수가 4개보다 적을 때 좌측부터 채워지고, 좌/우측 버튼은 보이지 않습니다.
- [x] Tablet에서 롤링 페이퍼 카드 목록 영역이 화면의 너비를 넘어갈 경우 터치로 좌우 스크롤 가능합니다.
- [x] Tablet에서 상단 네비게이션은 좌우 여백은 24px로 고정하고 '로고'와 '롤링 페이퍼 만들기' 버튼의 간격이 줄어들거나 커집니다.
- [x] Mobile에서 롤링 페이퍼 카드 목록 영역이 화면의 너비를 넘어갈 경우 터치로 좌우 스크롤 가능합니다.


+)
![카드 개수 4개 미만일때](https://github.com/Codeit-Sprint-Part2-5team/Rolling/assets/125109615/e7307d74-2386-44f2-850f-b11efa4a30f4)
카드 개수가 4개 미만일때 좌측부터 채워지는거 확인했습니다.